### PR TITLE
Add missing curly brace

### DIFF
--- a/src/test/scala/lms/tutorial/start.scala
+++ b/src/test/scala/lms/tutorial/start.scala
@@ -162,6 +162,7 @@ the second stage, driven by the type of their condition.
     }
     check("range2", snippet.code)
   }
+}
 /**
       .. includecode:: ../../../../out/dslapirange2.check.scala for
 


### PR DESCRIPTION
Sorry, I missed this detail in my previous PR.
This change fixed my build: all tests now pass when running `sbt test`.